### PR TITLE
Fixed mb_convert_encoding(): Illegal character encoding bug

### DIFF
--- a/src/PhpConsole/Connector.php
+++ b/src/PhpConsole/Connector.php
@@ -20,7 +20,7 @@ class Connector {
 	const SERVER_PROTOCOL = 5;
 	const SERVER_COOKIE = 'php-console-server';
 	const CLIENT_INFO_COOKIE = 'php-console-client';
-	const CLIENT_ENCODING = 'utf-8';
+	const CLIENT_ENCODING = 'UTF-8';
 	const HEADER_NAME = 'PHP-Console';
 	const POST_VAR_NAME = '__PHP_Console';
 	const SESSION_KEY = '__PHP_Console';


### PR DESCRIPTION
This was due to default encoding being set to 'utf-8' instead of 'UTF-8'
as per http://us1.php.net/manual/en/mbstring.supported-encodings.php
