### PR TITLE
Pass context parameter to old error handler

### DIFF
--- a/src/PhpConsole/Handler.php
+++ b/src/PhpConsole/Handler.php
@@ -168,7 +168,7 @@ class Handler {
 		$this->onHandlingStart();
 		$this->connector->getErrorsDispatcher()->dispatchError($code, $text, $file, $line, $skipCallsLevel + 1);
 		if($this->oldErrorsHandler && $this->callOldHandlers) {
-			call_user_func_array($this->oldErrorsHandler, array($code, $text, $file, $line));
+			call_user_func_array($this->oldErrorsHandler, array($code, $text, $file, $line, $context));
 		}
 		$this->onHandlingComplete();
 	}


### PR DESCRIPTION
I wanted to log php errors in conjunction with default error handler. But I failed because this one doesn't pass all required parameters to old error handler.
