### PR TITLE
Fix typing hinting for PHP7

### DIFF
--- a/src/PhpConsole/Dispatcher/Errors.php
+++ b/src/PhpConsole/Dispatcher/Errors.php
@@ -70,7 +70,7 @@ class Errors extends \PhpConsole\Dispatcher {
 	 * Send exception message to client
 	 * @param \Exception $exception
 	 */
-	public function dispatchException(\Exception $exception) {
+	public function dispatchException(\Throwable $exception) {
 		if($this->isActive()) {
 			if($this->dispatchPreviousExceptions && $exception->getPrevious()) {
 				$this->dispatchException($exception->getPrevious());

--- a/src/PhpConsole/EvalProvider.php
+++ b/src/PhpConsole/EvalProvider.php
@@ -41,7 +41,7 @@ class EvalProvider {
 		try {
 			$result->return = static::executeCode($code, $this->sharedVars);
 		}
-		catch(\Exception $exception) {
+		catch(\Throwable $exception) {
 			$result->exception = $exception;
 		}
 		$result->time = abs(microtime(true) - $startTime - $selfTime);

--- a/src/PhpConsole/Handler.php
+++ b/src/PhpConsole/Handler.php
@@ -210,7 +210,7 @@ class Handler {
 	 * Handle exception object
 	 * @param \Exception $exception
 	 */
-	public function handleException(\Exception $exception) {
+	public function handleException(\Throwable $exception) {
 		if(!$this->isStarted || $this->isHandlingDisabled()) {
 			return;
 		}
@@ -221,7 +221,7 @@ class Handler {
 				call_user_func($this->oldExceptionsHandler, $exception);
 			}
 		}
-		catch(\Exception $internalException) {
+		catch(\Throwable $internalException) {
 			$this->handleException($internalException);
 		}
 		$this->onHandlingComplete();

--- a/src/PhpConsole/OldVersionAdapter.php
+++ b/src/PhpConsole/OldVersionAdapter.php
@@ -97,7 +97,7 @@ namespace PhpConsole {
 			$this->getHandler()->handleError($code, $message, $file, $line, null, 1);
 		}
 
-		public function handleException(\Exception $exception) {
+		public function handleException(\Throwable $exception) {
 			$this->getHandler()->handleException($exception);
 		}
 

--- a/src/PhpConsole/PsrLogger.php
+++ b/src/PhpConsole/PsrLogger.php
@@ -62,7 +62,7 @@ class PsrLogger extends \Psr\Log\AbstractLogger {
 			$this->connector->getDebugDispatcher()->dispatchDebug($message, static::$debugLevels[$level], $this->ignoreTraceCalls);
 		}
 		elseif(isset(static::$errorsLevels[$level])) {
-			if(isset($context['exception']) && $context['exception'] instanceof \Exception) {
+			if(isset($context['exception']) && $context['exception'] instanceof \Throwable) {
 				$this->connector->getErrorsDispatcher()->dispatchException($context['exception']);
 			}
 			else {


### PR DESCRIPTION
In PHP7, most errors are now "exceptions" of type "class Error implements Throwable"
This is a quick fix to type hint for the interface \Throwable instead of the \Exception.