### PR TITLE
Add loopback address for ipv6 network to 'isLocal' check

### DIFF
--- a/src/PhpConsole/Connector.php
+++ b/src/PhpConsole/Connector.php
@@ -488,7 +488,7 @@ class Connector {
 					$response->auth = $this->auth->getServerAuthStatus($this->client->auth);
 				}
 				if(!$this->auth || $this->isAuthorized()) {
-					$response->isLocal = isset($_SERVER['REMOTE_ADDR']) && $_SERVER['REMOTE_ADDR'] == '127.0.0.1';
+					$response->isLocal = isset($_SERVER['REMOTE_ADDR']) && ($_SERVER['REMOTE_ADDR'] == '127.0.0.1' || $_SERVER['REMOTE_ADDR'] == '::1');
 					$response->docRoot = isset($_SERVER['DOCUMENT_ROOT']) ? $_SERVER['DOCUMENT_ROOT'] : null;
 					$response->sourcesBasePath = $this->sourcesBasePath;
 					$response->isEvalEnabled = $this->isEvalListenerStarted;


### PR DESCRIPTION
Jump to file doesn't work when 'isLocal' is set to 'false'. This is a problem in ipv6 networks where $_SERVER['REMOTE_ADDR'] is '::1' and not '127.0.0.1'.