### PR TITLE
Remove unncessary final, fixes PHP 8 compatibility

### DIFF
--- a/src/PhpConsole/Connector.php
+++ b/src/PhpConsole/Connector.php
@@ -98,7 +98,7 @@ class Connector {
 		$this->setServerEncoding(ini_get('mbstring.internal_encoding') ? : self::CLIENT_ENCODING);
 	}
 
-	private final function __clone() {
+	private function __clone() {
 	}
 
 	/**

--- a/src/PhpConsole/Handler.php
+++ b/src/PhpConsole/Handler.php
@@ -52,7 +52,7 @@ class Handler {
 	/**
 	 * @codeCoverageIgnore
 	 */
-	private final function __clone() {
+	private function __clone() {
 	}
 
 	/**


### PR DESCRIPTION
Using this library on PHP 8 leads to this warning:

> PHP Warning:  Private methods cannot be final as they are never overridden by other classes in vendor/php-console/php-console/src/PhpConsole/Connector.php on line 101

This PR fixes that in a less intrusive way than #171

closes #171